### PR TITLE
Add warning about non-fast-forward pushes

### DIFF
--- a/doc/00b_Using_the_Repo
+++ b/doc/00b_Using_the_Repo
@@ -336,4 +336,8 @@ zot (25): git log -1 --oneline --decorate master
     git merge rh
     git push tos master
 
+Under no circumstances should you perform a non-fast-forward push. See
+https://help.github.com/articles/dealing-with-non-fast-forward-errors
+for information on this.
+
 That's it.


### PR DESCRIPTION
I'm assuming that anybody with push privileges would know this already, but...
