### PR TITLE
Add .gitignore rules for built items in the tools/ directory

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -44,3 +44,10 @@ tinyos/safe/tos-decode-flid
 tinyos/safe/tos-ramsize
 tinyos/tosthreads/tosthreads_standard_api.py
 
+# Make
+*.so
+platforms/mica/cc1000-channelgen/tos-channelgen
+platforms/msp430/motelist/motelist
+tinyos/misc/tos-serial-debug
+tinyos/tosthreads/tosthreads-dynamic-app
+


### PR DESCRIPTION
Pattern rules were used where appropriate (and are listed first), but much of what is built doesn't match obvious patterns and is therefore explicitly listed instead.
