### PR TITLE
DELUGE: The initialization of local address signals ActiveMessageAddress.changed() 

### DIFF
--- a/tos/lib/net/Deluge/extra/NetProgC.nc
+++ b/tos/lib/net/Deluge/extra/NetProgC.nc
@@ -65,7 +65,7 @@ implementation {
   NetProgM.Leds -> LedsC;
   
   components ActiveMessageAddressC;
-  NetProgM.setAmAddress -> ActiveMessageAddressC;
+  NetProgM.initAmAddress -> ActiveMessageAddressC;
 
 #if !defined(PLATFORM_TINYNODE) && !defined(PLATFORM_MULLE)
   components CC2420ControlP;

--- a/tos/lib/net/Deluge/extra/NetProgM.nc
+++ b/tos/lib/net/Deluge/extra/NetProgM.nc
@@ -54,7 +54,7 @@ module NetProgM {
 #if !defined(PLATFORM_TINYNODE) && !defined(PLATFORM_MULLE)
     interface CC2420Config;
 #endif
-    async command void setAmAddress(am_addr_t a);
+    async command void initAmAddress(am_group_t myGroup, am_addr_t myAddr);
     interface ReprogramGuard;
   }
 }
@@ -71,7 +71,7 @@ implementation {
     // Update the local node ID
     if (bootArgs.address != 0xFFFF) {
       TOS_NODE_ID = bootArgs.address;
-      call setAmAddress(bootArgs.address);
+      call initAmAddress(TOS_AM_GROUP, bootArgs.address);
     }
 #if !defined(PLATFORM_TINYNODE) && !defined(PLATFORM_MULLE)
     call CC2420Config.setShortAddr(bootArgs.address);

--- a/tos/lib/net/Deluge/extra/iris/NetProgC.nc
+++ b/tos/lib/net/Deluge/extra/iris/NetProgC.nc
@@ -63,5 +63,5 @@ implementation {
   NetProgM.Leds -> LedsC;
 
   components ActiveMessageAddressC;
-  NetProgM.setAmAddress -> ActiveMessageAddressC;
+  NetProgM.initAmAddress -> ActiveMessageAddressC;
 }

--- a/tos/lib/net/Deluge/extra/iris/NetProgM.nc
+++ b/tos/lib/net/Deluge/extra/iris/NetProgM.nc
@@ -51,7 +51,7 @@ module NetProgM {
     interface InternalFlash as IFlash;
     interface Crc;
     interface Leds;
-    async command void setAmAddress(am_addr_t a);
+    async command void initAmAddress(am_group_t myGroup, am_addr_t myAddr);
   }
 }
 
@@ -65,7 +65,7 @@ implementation {
     // Update the local node ID
     if (bootArgs.address != 0xFFFF) {
       TOS_NODE_ID = bootArgs.address;
-      call setAmAddress(bootArgs.address);
+      call initAmAddress(TOS_AM_GROUP, bootArgs.address);
     }
 
     return SUCCESS;

--- a/tos/lib/tossim/ActiveMessageAddressC.nc
+++ b/tos/lib/tossim/ActiveMessageAddressC.nc
@@ -59,6 +59,7 @@ module ActiveMessageAddressC  {
     interface ActiveMessageAddress;
     async command am_addr_t amAddress();
     async command void setAmAddress(am_addr_t a);
+    async command void initAmAddress(am_group_t myGroup, am_addr_t myAddr);
   }
 }
 implementation {
@@ -87,6 +88,12 @@ implementation {
 
   async command am_addr_t amAddress() {
     return call ActiveMessageAddress.amAddress();
+  }
+
+  async command void initAmAddress(am_group_t myGroup, am_addr_t myAddr) {
+    addr = myAddr;
+    group = myGroup;
+    set = TRUE;
   }
 
   async command void setAmAddress(am_addr_t a) {

--- a/tos/system/ActiveMessageAddressC.nc
+++ b/tos/system/ActiveMessageAddressC.nc
@@ -54,6 +54,7 @@ module ActiveMessageAddressC @safe() {
     interface ActiveMessageAddress;
     async command am_addr_t amAddress();
     async command void setAmAddress(am_addr_t a);
+    async command void initAmAddress(am_group_t myGroup, am_addr_t myAddr);
   }
 }
 implementation {
@@ -96,6 +97,19 @@ implementation {
     return myGroup;
   }
   
+
+  /***************** Other Commands ****************/
+  /**
+   * Init the active message address of this node, without signaling of change
+   * @param group The node's group ID
+   * @param addr The node's active message address
+   */
+  async command void initAmAddress(am_group_t myGroup, am_addr_t myAddr) {
+    atomic {
+      addr = myAddr;
+      group = myGroup;
+    }
+  }
 
   /***************** Deprecated Commands ****************/
   /**


### PR DESCRIPTION
There is problem in Deluge start up. Deluge set up local address (TOS_NODE_ID and AMAddress)  from IFlash storage (eeprom). That is (correctly) done in MainC.SoftwareInit.
But call setAmAddress() signals the change to all linked components (signal ActiveMessageAddress.changed()) that is not even initialized.

I replaced setAmAddress() to new initAmAddress() that does not signal ActiveMessageAddress.changed(). The initAmAddress() stands outside interface ActiveMessageAddress.

M.C>
