### PR TITLE
DELUGE/AVR: image (with eeprom section) preparation and programming corrupts program 

### DIFF
--- a/tools/tinyos/misc/tos-build-deluge-image.in
+++ b/tools/tinyos/misc/tos-build-deluge-image.in
@@ -141,10 +141,11 @@ all = []
 section = []
 end_addr = None
 offset = 0
+addr_high = 0
 for line in image.split():
     #print "DEBUG:", line
     length = int(line[1:3], 16)
-    addr = int(line[3:7], 16) + offset
+    addr = int(line[3:7], 16) + offset + addr_high
     rectype = int(line[7:9], 16)
     data = []
     if len(line) > 11:
@@ -172,6 +173,8 @@ for line in image.split():
         all.append((start_addr, section))
         section = []
         start_addr = addr
+    elif rectype == 0x04:
+        addr_high = int(line[9:9+4], 16) << 16
 
 sys.stderr.write('Ihex read complete:\n')
 sys.stderr.write('  ' + '\n  '.join(["%5d bytes starting at 0x%X" % (len(l), a) for (a, l) in all]))

--- a/tos/lib/tosboot/TosBootP.nc
+++ b/tos/lib/tosboot/TosBootP.nc
@@ -189,9 +189,29 @@ implementation {
 	intAddr++; curAddr++;
 
 	if ( --secLength == 0 ) {
+		while (TRUE) {
 	  intAddr = extFlashReadAddr();
 	  secLength = extFlashReadAddr();
 	  curAddr = curAddr + 8;
+#if defined(PLATFORM_TELOSB) || defined (PLATFORM_EPIC) || defined (PLATFORM_TINYNODE)
+	  if (FALSE) {
+	  	// TODO: check of valid flash address range needed
+#elif defined(PLATFORM_MICAZ) || defined(PLATFORM_IRIS)
+	  if (intAddr > FLASHEND) {
+	  	// ram, eeprom, fuses ... programming not supported
+#elif defined(PLATFORM_MULLE)
+ 	  if (FALSE) {
+	  	// TODO: check of valid flash address range needed
+#else
+  #error "Target platform is not currently supported by Deluge T2"
+#endif
+	  	curAddr += secLength; // skip block
+	  	call ExtFlash.stopRead();
+	  	call ExtFlash.startRead(curAddr);
+	  	continue;
+	  	}
+	  	break;
+	  }
 	}
 
 	newPageAddr = intAddr / TOSBOOT_INT_PAGE_SIZE;


### PR DESCRIPTION
There is problem with deluge ihex image processing.
The "eeprom" (EEMEM tag) section in AVR model is mapped to address 0x810000
that is encoded with 0x04 ihex command. Before patch there is not support for 0x04 and "eeprom" data fatally overrides program at beginning of program flash (address 0x0) by tosboot.

The tos-build-deluge-image should support for ihex 0x04 command. 
The tosboot booltloader should check valid ranges for flash programming.

The patch is not complete. Platform like PLATFORM_TELOSB, PLATFORM_EPIC, PLATFORM_TINYNODE, PLATFORM_MULLE should be checked and code added in range check (see TODO in patch).

M.C>

PS: example output of patched tos-build-deluge-image:

```
Ihex read complete:
  61022 bytes starting at 0x0
      2 bytes starting at 0x810000
  61024 bytes in 2 sections
CRCs:
  0x89B8 0xFC38 0x0DD3 0xCEE6 0xAD9B 0x357C 0x30A5 
  0x2785 0xA317 0xD723 0xD89B 0xF4E8 0x5E60 0xA69C 
  0x7ADF 0xF47F 0x67D3 0x7429 0xF0D4 0x2F80 0x9BB1 
  0x1694 0x2C8B 0x7091 0x15F4 0x8D89 0x2D4C 0xA0B3 
  0x4DA0 0xCBBA 0x09DB 0x01DA 0xD12F 0x8700 0xF785 
  0xA0B0 0x07CD 0x509F 0xC44D 0x22F5 0x1599 0xD5C9 
  0xDC11 0x1671 0x63E4 0x33B5 0xCE38 0x8184 0x973D 
  0xBF45 0x208F 0xB74B 0x73D4 0x43B0 0x6A22 0xF2AA 
```
