### PR TITLE
DELUGE: tos-deluge corrupts mote ram data (AT45DB erase/inject commands)

### DIFF
--- a/tools/tinyos/misc/tos-deluge.in
+++ b/tools/tinyos/misc/tos-deluge.in
@@ -74,6 +74,7 @@ ERROR_FAIL    = 1   # T2-compatible
 DELUGE_MAX_PAGES    = 128
 DELUGE_IDENT_OFFSET = 0
 DELUGE_IDENT_SIZE   = 128
+DELUGE_IDENT_UID_SIZE = 4
 
 class FMReqPacket(tos.Packet):
     def __init__(self, packet = None):
@@ -206,8 +207,8 @@ def erase(imgNum):
 
     print 'Attempt the workaround for AT45DB...'
     sreqpkt = FMReqPacket((FM_CMD_WRITE, imgNum, 0, 0, []))
-    sreqpkt.data = [0xFF] * DELUGE_IDENT_SIZE
-    sreqpkt.length = DELUGE_IDENT_SIZE
+    sreqpkt.data = [0xFF] * DELUGE_IDENT_UID_SIZE
+    sreqpkt.length = DELUGE_IDENT_UID_SIZE
     success = am.write(sreqpkt, FM_AMID)
     result = handleResponse(success, "ERROR: Unable to erase the flash volume")
     if not result: return False;


### PR DESCRIPTION
"tos-deluge" corrupts mote ram data when erasing "ident" header (AT45DB erase/inject commands).

It is part of  AT45DB erasing. "tos-deluge" sends too large serial packet and memcpy() destroys mote ram data. "tos-deluge" is trying to write "0xff" \* DELUGE_IDENT_SIZE (==128) that is larger than usual serial packet length (SERIAL_DATA_LENGTH==28-8) and that is larger than prepared buffer size (uint8_t buffer[TOSH_DATA_LENGTH]).

Erasing of "nx_uint32_t uidhash;" at the begining of DelugeIdent structure seems to be sufficient.

M.C>
