### PR TITLE
Removed unused include directory lib/T2Hack from Makefile in NxFloat and TestSerial apps

### DIFF
--- a/apps/tests/NxFloat/Makefile
+++ b/apps/tests/NxFloat/Makefile
@@ -2,8 +2,6 @@ COMPONENT=TestSerialAppC
 BUILD_EXTRA_DEPS += TestSerial.class
 CLEAN_EXTRA = *.class TestSerialMsg.java
 
-CFLAGS += -I$(TOSDIR)/lib/T2Hack
-
 TestSerial.class: $(wildcard *.java) TestSerialMsg.java
 	javac -target 1.4 -source 1.4 *.java
 

--- a/apps/tests/TestSerial/Makefile
+++ b/apps/tests/TestSerial/Makefile
@@ -2,8 +2,6 @@ COMPONENT=TestSerialAppC
 BUILD_EXTRA_DEPS += TestSerial.class
 CLEAN_EXTRA = *.class TestSerialMsg.java
 
-CFLAGS += -I$(TOSDIR)/lib/T2Hack
-
 TestSerial.class: $(wildcard *.java) TestSerialMsg.java
 	javac -target 1.4 -source 1.4 *.java
 


### PR DESCRIPTION
This is a small patch to remove a non-existing include directory from the Makefile of apps/tests/NxFloat and apps/tests/TestSerial:

CFLAGS += -I$(TOSDIR)/lib/T2Hack

Both applications try to include $(TOSDIR)/lib/T2Hack which does not exist in tinyos-main.
