### PR TITLE
make new ncc (platform vs. .platform) backward compatible

### DIFF
--- a/tos/.default-platform
+++ b/tos/.default-platform
@@ -1,0 +1,1 @@
+tos/default-platform

--- a/tos/platforms/btnode3/.platform
+++ b/tos/platforms/btnode3/.platform
@@ -1,0 +1,1 @@
+tos/platforms/btnode3/platform

--- a/tos/platforms/epic/.platform
+++ b/tos/platforms/epic/.platform
@@ -1,0 +1,1 @@
+tos/platforms/epic/platform

--- a/tos/platforms/eyesIFX/.family
+++ b/tos/platforms/eyesIFX/.family
@@ -1,0 +1,1 @@
+tos/platforms/eyesIFX/family

--- a/tos/platforms/eyesIFX/eyesIFXv1/.platform
+++ b/tos/platforms/eyesIFX/eyesIFXv1/.platform
@@ -1,0 +1,1 @@
+tos/platforms/eyesIFX/eyesIFXv1/platform

--- a/tos/platforms/eyesIFX/eyesIFXv2/.platform
+++ b/tos/platforms/eyesIFX/eyesIFXv2/.platform
@@ -1,0 +1,1 @@
+tos/platforms/eyesIFX/eyesIFXv2/platform

--- a/tos/platforms/intelmote2/.platform
+++ b/tos/platforms/intelmote2/.platform
@@ -1,0 +1,1 @@
+tos/platforms/intelmote2/platform

--- a/tos/platforms/iris/.platform
+++ b/tos/platforms/iris/.platform
@@ -1,0 +1,1 @@
+tos/platforms/iris/platform

--- a/tos/platforms/iris/sim/.platform
+++ b/tos/platforms/iris/sim/.platform
@@ -1,0 +1,1 @@
+tos/platforms/iris/sim/platform

--- a/tos/platforms/mica2/.platform
+++ b/tos/platforms/mica2/.platform
@@ -1,0 +1,1 @@
+tos/platforms/mica2/platform

--- a/tos/platforms/mica2dot/.platform
+++ b/tos/platforms/mica2dot/.platform
@@ -1,0 +1,1 @@
+tos/platforms/mica2dot/platform

--- a/tos/platforms/micaz/.platform
+++ b/tos/platforms/micaz/.platform
@@ -1,0 +1,1 @@
+tos/platforms/micaz/platform

--- a/tos/platforms/micaz/sim/.platform
+++ b/tos/platforms/micaz/sim/.platform
@@ -1,0 +1,1 @@
+tos/platforms/micaz/sim/platform

--- a/tos/platforms/mulle/.platform
+++ b/tos/platforms/mulle/.platform
@@ -1,0 +1,1 @@
+tos/platforms/mulle/platform

--- a/tos/platforms/null/.platform
+++ b/tos/platforms/null/.platform
@@ -1,0 +1,1 @@
+tos/platforms/null/platform

--- a/tos/platforms/sam3s_ek/.platform
+++ b/tos/platforms/sam3s_ek/.platform
@@ -1,0 +1,1 @@
+tos/platforms/sam3s_ek/platform

--- a/tos/platforms/sam3u_ek/.platform
+++ b/tos/platforms/sam3u_ek/.platform
@@ -1,0 +1,1 @@
+tos/platforms/sam3u_ek/platform

--- a/tos/platforms/shimmer/.platform
+++ b/tos/platforms/shimmer/.platform
@@ -1,0 +1,1 @@
+tos/platforms/shimmer/platform

--- a/tos/platforms/shimmer2/.platform
+++ b/tos/platforms/shimmer2/.platform
@@ -1,0 +1,1 @@
+tos/platforms/shimmer2/platform

--- a/tos/platforms/shimmer2r/.platform
+++ b/tos/platforms/shimmer2r/.platform
@@ -1,0 +1,1 @@
+tos/platforms/shimmer2r/platform

--- a/tos/platforms/span/.platform
+++ b/tos/platforms/span/.platform
@@ -1,0 +1,1 @@
+tos/platforms/span/platform

--- a/tos/platforms/telosa/.platform
+++ b/tos/platforms/telosa/.platform
@@ -1,0 +1,1 @@
+tos/platforms/telosa/platform

--- a/tos/platforms/telosb/.platform
+++ b/tos/platforms/telosb/.platform
@@ -1,0 +1,1 @@
+tos/platforms/telosb/platform

--- a/tos/platforms/tinynode/.platform
+++ b/tos/platforms/tinynode/.platform
@@ -1,0 +1,1 @@
+tos/platforms/tinynode/platform

--- a/tos/platforms/ucbase/.platform
+++ b/tos/platforms/ucbase/.platform
@@ -1,0 +1,1 @@
+tos/platforms/ucbase/platform

--- a/tos/platforms/ucmini/.platform
+++ b/tos/platforms/ucmini/.platform
@@ -1,0 +1,1 @@
+tos/platforms/ucmini/platform

--- a/tos/platforms/ucprotonb/.platform
+++ b/tos/platforms/ucprotonb/.platform
@@ -1,0 +1,1 @@
+tos/platforms/ucprotonb/platform

--- a/tos/platforms/z1/.platform
+++ b/tos/platforms/z1/.platform
@@ -1,0 +1,1 @@
+tos/platforms/z1/platform

--- a/tos/sensorboards/basicsb/.sensor
+++ b/tos/sensorboards/basicsb/.sensor
@@ -1,0 +1,1 @@
+tos/sensorboards/basicsb/sensor

--- a/tos/sensorboards/im2sb/.sensor
+++ b/tos/sensorboards/im2sb/.sensor
@@ -1,0 +1,1 @@
+tos/sensorboards/im2sb/sensor

--- a/tos/sensorboards/mda100/.sensor
+++ b/tos/sensorboards/mda100/.sensor
@@ -1,0 +1,1 @@
+tos/sensorboards/mda100/sensor

--- a/tos/sensorboards/mts300/.sensor
+++ b/tos/sensorboards/mts300/.sensor
@@ -1,0 +1,1 @@
+tos/sensorboards/mts300/sensor

--- a/tos/sensorboards/mts400/.sensor
+++ b/tos/sensorboards/mts400/.sensor
@@ -1,0 +1,1 @@
+tos/sensorboards/mts400/sensor


### PR DESCRIPTION
We've moved .platform (and .family and .sensor) to non-dot
files so they are visible.  This requires a new version of ncc
(included in the tinyos-tools package) which isn't out yet.

In the meantime, make the new structure backward compatible with the
old ncc.   (simple symbolic links to new non-dot files).

closes #197
