### PR TITLE
Remove the full path to nescc from ncc, ncg, mig

### DIFF
--- a/tools/configure.ac
+++ b/tools/configure.ac
@@ -2,9 +2,9 @@
 # Copyright (c) 2005 Intel Corporation
 # All rights reserved.
 #
-# This file is distributed under the terms in the attached INTEL-LICENSE     
+# This file is distributed under the terms in the attached INTEL-LICENSE
 # file. If you do not find these files, copies can be found by writing to
-# Intel Research Berkeley, 2150 Shattuck Avenue, Suite 1300, Berkeley, CA, 
+# Intel Research Berkeley, 2150 Shattuck Avenue, Suite 1300, Berkeley, CA,
 # 94704.  Attention:  Intel License Inquiry.
 
 dnl -*- m4 -*-
@@ -23,26 +23,18 @@ AC_PROG_RANLIB
 
 AC_PATH_PROG(pathperl, perl)
 if test -z "$pathperl" ; then
-  AC_MSG_ERROR(I can't find perl); 
+  AC_MSG_ERROR(I can't find perl);
 fi
 
 AC_PATH_PROGS(pathpython, [python2 python])
 if test -z "$pathpython" ; then
-  AC_MSG_ERROR(I can't find python); 
+  AC_MSG_ERROR(I can't find python);
 fi
 
-if test -z "$NESCC_PREFIX"; then
-  AC_PATH_PROG(pathnescc, nescc)
-  if test -z "$pathnescc"; then
-    AC_MSG_ERROR(I can't find nescc)
-  else
-    NESCC_PREFIX=`dirname "$pathnescc"`
-    NESCC_PREFIX=`dirname "$NESCC_PREFIX"`
-  fi
+AC_PATH_PROG(pathnescc, nescc)
+if test -z "$pathnescc"; then
+  AC_MSG_ERROR(I can't find nescc)
 fi
-nescc_prefix=`(cd $NESCC_PREFIX;pwd)`
-AC_SUBST(nescc_prefix)
-
 
 if test -z "$DEFAULT_TARGET"; then
   DEFAULT_TARGET=mica

--- a/tools/tinyos/ncc/mig.in
+++ b/tools/tinyos/ncc/mig.in
@@ -2,15 +2,15 @@
 # Copyright (c) 2005 Intel Corporation
 # All rights reserved.
 #
-# This file is distributed under the terms in the attached INTEL-LICENSE     
+# This file is distributed under the terms in the attached INTEL-LICENSE
 # file. If you do not find these files, copies can be found by writing to
-# Intel Research Berkeley, 2150 Shattuck Avenue, Suite 1300, Berkeley, CA, 
+# Intel Research Berkeley, 2150 Shattuck Avenue, Suite 1300, Berkeley, CA,
 # 94704.  Attention:  Intel License Inquiry.
 
 
 prefix="@prefix@";
 exec_prefix="@exec_prefix@";
-exec "@nescc_prefix@/bin/nescc-mig" "-nescc=$exec_prefix/bin/ncc" "$@"
+exec "nescc-mig" "-nescc=$exec_prefix/bin/ncc" "$@"
 err=$?
-echo "Couldn't execute @nescc_prefix@/bin/nescc-mig" >&2
+echo "Couldn't execute nescc-mig" >&2
 exit $err

--- a/tools/tinyos/ncc/ncc.in
+++ b/tools/tinyos/ncc/ncc.in
@@ -11,7 +11,7 @@
 
 # Configuration
 $TOSDIR = $ENV{"TOSDIR"} if defined($ENV{"TOSDIR"});
-$nescc = "@nescc_prefix@/bin/nescc";
+$nescc = "nescc";
 $tossim = 0;
 $is_tos_1 = 0;
 $with_scheduler_flag = 1;

--- a/tools/tinyos/ncc/ncg.in
+++ b/tools/tinyos/ncc/ncg.in
@@ -2,15 +2,15 @@
 # Copyright (c) 2005 Intel Corporation
 # All rights reserved.
 #
-# This file is distributed under the terms in the attached INTEL-LICENSE     
+# This file is distributed under the terms in the attached INTEL-LICENSE
 # file. If you do not find these files, copies can be found by writing to
-# Intel Research Berkeley, 2150 Shattuck Avenue, Suite 1300, Berkeley, CA, 
+# Intel Research Berkeley, 2150 Shattuck Avenue, Suite 1300, Berkeley, CA,
 # 94704.  Attention:  Intel License Inquiry.
 
 
 prefix="@prefix@";
 exec_prefix="@exec_prefix@";
-exec "@nescc_prefix@/bin/nescc-ncg" "-nescc=$exec_prefix/bin/ncc" "$@"
+exec "nescc-ncg" "-nescc=$exec_prefix/bin/ncc" "$@"
 err=$?
-echo "Couldn't execute @nescc_prefix@/bin/nescc-ncg" >&2
+echo "Couldn't execute nescc-ncg" >&2
 exit $err


### PR DESCRIPTION
Let $PATH determine which nescc to use. This way if the path to nescc changes after someone installs tinyos-tools, ncc will continue to work.

Fixes #198
