### PR TITLE
Removed -shared flag from java jni on mac

### DIFF
--- a/tools/tinyos/java/env/Makefile.am
+++ b/tools/tinyos/java/env/Makefile.am
@@ -8,9 +8,9 @@ tinyoslib_PROGRAMS = @GETENVLIB@
 
 EXTRA_PROGRAMS = libgetenv.so getenv.dll libgetenv.jnilib
 
-LIBFLAGS = "-I$(JDK)/include" -s -shared -O2
-SOFLAGS = $(LIBFLAGS) "-I$(JDK)/include/linux" -fpic
-DLLFLAGS = $(LIBFLAGS) "-I$(JDK)/include/win32" -D_JNI_IMPLEMENTATION -Wl,--kill-at
+LIBFLAGS = "-I$(JDK)/include" -s -O2
+SOFLAGS = $(LIBFLAGS) "-I$(JDK)/include/linux" -shared -fpic
+DLLFLAGS = $(LIBFLAGS) "-I$(JDK)/include/win32" -shared -D_JNI_IMPLEMENTATION -Wl,--kill-at
 JNILIBFLAGS = $(LIBFLAGS) "-I$(JDK)/Headers" -bundle -fPIC
 
 #first file should be the main c/cpp file

--- a/tools/tinyos/java/serial/Makefile.am
+++ b/tools/tinyos/java/serial/Makefile.am
@@ -13,9 +13,9 @@ EXTRA_PROGRAMS = libtoscomm.so toscomm.dll libtoscomm.jnilib
 # Compiling libtoscomm.so with -O2 generates bad code with gcc 4.1.x on x86_64
 # (the -O1 code is slightly weird, but works at least ;-))
 
-LIBFLAGS = "-I$(JDK)/include" -s -shared -O2
-SOFLAGS = $(LIBFLAGS) "-I$(JDK)/include/linux" -fPIC
-DLLFLAGS = $(LIBFLAGS) "-I$(JDK)/include/win32" -D_JNI_IMPLEMENTATION -Wl,--kill-at
+LIBFLAGS = "-I$(JDK)/include" -s -O2
+SOFLAGS = $(LIBFLAGS) "-I$(JDK)/include/linux" -shared -fPIC
+DLLFLAGS = $(LIBFLAGS) "-I$(JDK)/include/win32" -shared -D_JNI_IMPLEMENTATION -Wl,--kill-at
 JNILIBFLAGS = $(LIBFLAGS) "-I$(JDK)/Headers" -bundle
 
 libtoscomm_common_SOURCES = \


### PR DESCRIPTION
-shared flag causes building tinyos-tools to fail on mac 10.8.3.

Fixes #205
