### PR TITLE
fix handling of MUX5 bit in ADC channels for rfa1

### DIFF
--- a/tos/chips/atm128rfa1/adc/HplAtm128AdcP.nc
+++ b/tos/chips/atm128rfa1/adc/HplAtm128AdcP.nc
@@ -51,15 +51,16 @@ module HplAtm128AdcP @safe() {
 }
 implementation {
   async command void HplAtm128Adc.setChannel(uint8_t mux){
-    ADMUX = (ADMUX & 0xE0) | (mux & 0x1F); //upper 3 bits: unchanged; lower 5 bits: mux
+    // need to write MUX5 before MUX4:0 (atmega128rfa1 datasheet rev. 8266d-MCU section 27.6.1)    
     if(mux & 0x20)
       ADCSRB |= (1 << MUX5);
     else
-      ADCSRB &= ~(1 << MUX5);    
+      ADCSRB &= ~(1 << MUX5);
+    ADMUX = (ADMUX & 0xE0) | (mux & 0x1F); //upper 3 bits: unchanged; lower 5 bits: mux
   }
   
   async command uint8_t HplAtm128Adc.getChannel(){
-    return (ADMUX & 0x1F) | (((ADCSRB & MUX5) >> MUX5) << 5);
+    return (ADMUX & 0x1F) | (((ADCSRB & (1<<MUX5)) >> MUX5) << 5);
   }
   
   async command void HplAtm128Adc.setAdlar(bool adlarOn){


### PR DESCRIPTION
There is a bug in tos/chips/atm128rfa1/adc/HplAtm128AdcP.nc with ADC channels that use MUX5 bit. As stated in version 8266D-MCU of the atmega128rfa1 datasheet, section 27.6.1, bit MUX5 is buffered and only written on a consecutive write to MUX4:0. Therefore, need to write MUX5 first, then MUX4:0.

Also fixed a small bug when reading the channel. MUX5 bit was used as such ((ADCSRB & MUX5) but should be ((ADCSRB & (1<<MUX5)).
