### PR TITLE
BLIP printf() Small Fix

### DIFF
--- a/tos/lib/net/blip/blip_printf.h
+++ b/tos/lib/net/blip/blip_printf.h
@@ -67,11 +67,11 @@ int printf_ieee154addr(ieee154_addr_t *in) {
 #if defined (_H_msp430hardware_h) || defined (_H_atmega128hardware_H)
   #include <stdio.h>
 #else
-#ifdef __M16C60HARDWARE_H__ 
+#ifdef __M16C60HARDWARE_H__
   #include "m16c60_printf.h"
 #else
   #include "generic_printf.h"
-#endif 
+#endif
 #endif
 #undef putchar
 
@@ -81,6 +81,7 @@ int printf_ieee154addr(ieee154_addr_t *in) {
 #define printf_in6addr(a) ;
 #define printf_buf(buf, len) ;
 #define iov_print(iov) ;
+#define printf_ieee154addr(in) ;
 
 #endif /* PRINTFUART_ENABLED */
 


### PR DESCRIPTION
If `PRINTFUART` is not defined, `blip_printf.h` now correctly removes all the `printf` functions. `printf_ieee154addr()` was not being removed but that wasn't a problem because it isn't called anywhere. But, if someone did want to use it, their code would not compile with `printf` debugging turned off.
