### PR TITLE
clocks variable for each port

### DIFF
--- a/tos/chips/cortex/m3/sam3/pins/HplSam3GeneralIOPortP.nc
+++ b/tos/chips/cortex/m3/sam3/pins/HplSam3GeneralIOPortP.nc
@@ -33,7 +33,6 @@
  * @author Thomas Schmid
  */
 
-uint32_t clocks = 0;
 generic module HplSam3GeneralIOPortP(uint32_t pio_addr)
 {
     provides
@@ -49,6 +48,7 @@ generic module HplSam3GeneralIOPortP(uint32_t pio_addr)
 }
 implementation
 {
+    uint32_t clocks = 0;
     uint32_t isr = 0;
 
     bool isPending(uint8_t bit)


### PR DESCRIPTION
This patch fixes a bug where different ports of the CPU store the clock state all ports in the same variable, where they should actually be stored separately.
