### PR TITLE
Updated tos-locate-jre for recent Xcode

### DIFF
--- a/tools/tinyos/misc/tos-locate-jre
+++ b/tools/tinyos/misc/tos-locate-jre
@@ -75,7 +75,7 @@ case `uname` in
     ## Since we only want to modify this one script for now, stick the
     ## extra subdir at the end, beceuase that's what the reset of scripts
     ## presume. This is a work-around and should be eliminated eventually.
-    xcode_jdk=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/${pn}${pv}.sdk/System/Library/Frameworks/JavaVM.framework/Versions/A/Headers
+    xcode_jdk=/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers
     jhome=/Library/Java/Home
     ;;
 


### PR DESCRIPTION
Xcode is now in /Applications/Xcode.app for a pretty long time, so no fallback option is provided, you really should have moved from /Developer by this time.
