### PR TITLE
Trivial typo fix in PppRouter

### DIFF
--- a/apps/PppRouter/PppRouterC.nc
+++ b/apps/PppRouter/PppRouterC.nc
@@ -60,7 +60,7 @@ configuration PppRouterC {
   // components RouteCmdC;
 
 #ifdef IN6_PREFIX
-  components StaticIpAddressC;
+  components StaticIPAddressC;
 #else
   components Dhcp6C;
   components Dhcp6ClientC;


### PR DESCRIPTION
Trivial typo that prevents PppRouter from building with default makefiles.

Before patch:

```
me@box:~/tinyos-main/apps/PppRouter$ make epic blip
[...snippage...]
In component `PppRouterC':
PppRouterC.nc:63: component StaticIpAddressC not found
make: *** [exe0] Error 1
```

After patch:

```
me@box:~/tinyos-main/apps/PppRouter$ make epic blip
[...snippage...]
   compiled PppRouterC to build/epic/main.exe
          48464 bytes in ROM
           9516 bytes in RAM
msp430-objcopy --output-target=ihex build/epic/main.exe build/epic/main.ihex
writing TOS image
```
