### PR TITLE
CTP can receive message duplicates. The protocol uses the SentCache to

### DIFF
--- a/tos/lib/net/ctp/CtpForwardingEngineP.nc
+++ b/tos/lib/net/ctp/CtpForwardingEngineP.nc
@@ -712,12 +712,14 @@ implementation {
     }
 
     // If I'm the root, signal receive. 
-    else if (call RootControl.isRoot())
+    else if (call RootControl.isRoot()) {
+      call SentCache.insert(msg);
       return signal Receive.receive[collectid](msg, 
 					       call Packet.getPayload(msg, call Packet.payloadLength(msg)), 
 					       call Packet.payloadLength(msg));
     // I'm on the routing path and Intercept indicates that I
     // should not forward the packet.
+    }
     else if (!signal Intercept.forward[collectid](msg, 
 						  call Packet.getPayload(msg, call Packet.payloadLength(msg)), 
 						  call Packet.payloadLength(msg)))


### PR DESCRIPTION
detect duplicates: when CTP sends a message, it updates the cache
record.

CTP does not update the cache when the message is received at the root
(since the root does not forward/send the message further). This
results in message duplicates at the root.

Added SentCache.insert at the root node, before it signals to the upper layer
receving of a new message. This way, message duplicates are also eliminated at
the last hop, with destination at the root.
