### PR TITLE
Implements more EBUSY on Resource.request() (TEP108)

### DIFF
--- a/tos/system/SimpleArbiterP.nc
+++ b/tos/system/SimpleArbiterP.nc
@@ -76,7 +76,8 @@ implementation {
         post grantedTask();
         return SUCCESS;
       }
-      return call Queue.enqueue(id);
+      if ((state == RES_GRANTING) && (resId == id)) return EBUSY;
+      else return call Queue.enqueue(id);
     }
   }
 


### PR DESCRIPTION
There is problem with multiple calls to SimpleArbiterP.nc Resource.request().

Problem description - call 3x Resource.request() in one task:
1) resource is free (state == RES_IDLE )
2) 1. call Resource.request() returns **SUCCESS** (state == RES_GRANTING) and post is planned
3) 2. call Resource.request() returns **SUCCESS** !!! (state == RES_GRANTING) and id is queued (Queue.enqueue(id))
4) 3. call Resource.request() returns **EBUSY** (state == RES_GRANTING) and id is already queued (see ResourceQueue).

TEP108: 3.1 "... If a client ever makes multiple requests before receiving a granted event, an EBUSY value is returned, and the request is not queued. ..."

I suppose that correct return code for 3) is **EBUSY** too and **NOT** queue request.
I have problem with that, Resource.granted is called 2 times and if I do everything with first call,
there is no work for the second call.

There are similar problems with ArbiterP.nc (that return **SUCCESS** instead **EBUSY**), FcfsPriorityArbiterC.nc.
