### PR TITLE
packaging: update nesc build.sh

### DIFF
--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,0 +1,3 @@
+packages
+nesc/nesc-*
+tinyos-tools/tinyos-tools-*

--- a/packaging/nesc/build.sh
+++ b/packaging/nesc/build.sh
@@ -33,7 +33,7 @@ fi
 echo -e "\n*** TOSROOT: $TOSROOT"
 echo      "*** Destination: ${DEB_DEST}"
 
-NESC_VER=1.3.4
+NESC_VER=1.3.5
 NESC=nesc-${NESC_VER}
 
 setup_deb()
@@ -64,7 +64,7 @@ download()
 {
     echo -e "\n*** Downloading ... ${NESC}"
     [[ -a ${NESC}.tar.gz ]] \
-	|| wget http://downloads.sourceforge.net/project/nescc/nescc/v${NESC_VER}/${NESC}.tar.gz
+	|| wget https://github.com/tinyos/nesc/archive/v${NESC_VER}.tar.gz -O ${NESC}.tar.gz
 }
 
 build()
@@ -75,6 +75,7 @@ build()
     set -e
     (
 	cd ${NESC}
+	./Bootstrap
 	./configure --prefix=${PREFIX}
 	make ${MAKE_J}
 	make install-strip

--- a/packaging/nesc/nesc.control
+++ b/packaging/nesc/nesc.control
@@ -5,6 +5,7 @@ Priority: optional
 Architecture: @architecture@
 Depends: perl, libc6-dev|libc-dev
 Recommends: graphviz, java-sdk
-Maintainer: Razvan Musaloiu-E. <razvan@musaloiu.com>, Eric B. Decker <cire831@gmail.com>
+Installed-Size: 859
+Maintainer: Razvan Musaloiu-E. <razvan@musaloiu.com>
 Description: This is the nesC compiler used to compile TinyOS applications, includes support
   for gcc 4.7 (ver > 1.3.3).


### PR DESCRIPTION
This updates the build.sh script in the packaging/nesc folder to nesc 1.3.5 (which now comes from github).

It also changes nesc.control to meet current debian standards (as tested on Ubuntu 13.10).
