### PR TITLE
Use channel 26 on all radios

### DIFF
--- a/tos/chips/cc2420x/CC2420XDriverLayer.h
+++ b/tos/chips/cc2420x/CC2420XDriverLayer.h
@@ -154,7 +154,7 @@ static const cc2420X_txctrl_t cc2420X_txctrl_default = {.f.pa_level = 31, .f.res
 
 
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL 11
+#define CC2420X_DEF_CHANNEL 26
 #endif
 
 #ifndef CC2420X_DEF_RFPOWER

--- a/tos/chips/cc2520/CC2520DriverLayer.h
+++ b/tos/chips/cc2520/CC2520DriverLayer.h
@@ -243,7 +243,7 @@ typedef union cc2520_adctest2 {
 static cc2520_adctest2_t cc2520_adctest2_default = {.value = 0x03};
 
 #ifndef CC2520_DEF_CHANNEL
-#define CC2520_DEF_CHANNEL 25
+#define CC2520_DEF_CHANNEL 26
 #endif
 
 #ifndef CC2520_DEF_RFPOWER

--- a/tos/platforms/iris/chips/rf230/RadioConfig.h
+++ b/tos/platforms/iris/chips/rf230/RadioConfig.h
@@ -67,7 +67,7 @@ enum
 
 /* This is the default value of the CHANNEL field of the PHY_CC_CCA register. */
 #ifndef RF230_DEF_CHANNEL
-#define RF230_DEF_CHANNEL	11
+#define RF230_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending IRIS mote will wait for an acknowledgement */

--- a/tos/platforms/micaz/chips/cc2420x/RadioConfig.h
+++ b/tos/platforms/micaz/chips/cc2420x/RadioConfig.h
@@ -35,7 +35,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/mulle/chips/rf230/RadioConfig.h
+++ b/tos/platforms/mulle/chips/rf230/RadioConfig.h
@@ -101,7 +101,7 @@ enum
 
 /* This is the default value of the CHANNEL field of the PHY_CC_CCA register. 11-26*/
 #ifndef RF230_DEF_CHANNEL
-#define RF230_DEF_CHANNEL	11
+#define RF230_DEF_CHANNEL	26
 #endif
 
 /*

--- a/tos/platforms/sam3s_ek/chips/cc2520/RadioConfig.h
+++ b/tos/platforms/sam3s_ek/chips/cc2520/RadioConfig.h
@@ -47,7 +47,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2520_DEF_CHANNEL
-#define CC2520_DEF_CHANNEL	11
+#define CC2520_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending mote will wait for an acknowledgement */

--- a/tos/platforms/shimmer/chips/cc2420x/t32khz/RadioConfig.h
+++ b/tos/platforms/shimmer/chips/cc2420x/t32khz/RadioConfig.h
@@ -35,7 +35,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/shimmer/chips/cc2420x/tmicro/RadioConfig.h
+++ b/tos/platforms/shimmer/chips/cc2420x/tmicro/RadioConfig.h
@@ -35,7 +35,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/shimmer2/chips/cc2420x/t32khz/RadioConfig.h
+++ b/tos/platforms/shimmer2/chips/cc2420x/t32khz/RadioConfig.h
@@ -39,7 +39,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/shimmer2/chips/cc2420x/tmicro/RadioConfig.h
+++ b/tos/platforms/shimmer2/chips/cc2420x/tmicro/RadioConfig.h
@@ -39,7 +39,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/telosa/chips/cc2420x/t32khz/RadioConfig.h
+++ b/tos/platforms/telosa/chips/cc2420x/t32khz/RadioConfig.h
@@ -35,7 +35,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/telosa/chips/cc2420x/tmicro/RadioConfig.h
+++ b/tos/platforms/telosa/chips/cc2420x/tmicro/RadioConfig.h
@@ -35,7 +35,7 @@
 
 /* This is the default value of the CHANNEL field of the FSCTRL register. */
 #ifndef CC2420X_DEF_CHANNEL
-#define CC2420X_DEF_CHANNEL	11
+#define CC2420X_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending micaz mote will wait for an acknowledgement */

--- a/tos/platforms/ucbase/RadioConfig.h
+++ b/tos/platforms/ucbase/RadioConfig.h
@@ -84,7 +84,7 @@ enum
 
 /* This is the default value of the CHANNEL field of the PHY_CC_CCA register. */
 #ifndef RFA1_DEF_CHANNEL
-#define RFA1_DEF_CHANNEL	11
+#define RFA1_DEF_CHANNEL	26
 #endif
 
 

--- a/tos/platforms/ucmini/RadioConfig.h
+++ b/tos/platforms/ucmini/RadioConfig.h
@@ -65,7 +65,7 @@ enum
 
 /* This is the default value of the CHANNEL field of the PHY_CC_CCA register. */
 #ifndef RFA1_DEF_CHANNEL
-#define RFA1_DEF_CHANNEL	11
+#define RFA1_DEF_CHANNEL	26
 #endif
 
 /* The number of microseconds a sending mote will wait for an acknowledgement */

--- a/tos/platforms/ucprotonb/RadioConfig.h
+++ b/tos/platforms/ucprotonb/RadioConfig.h
@@ -84,7 +84,7 @@ enum
 
 /* This is the default value of the CHANNEL field of the PHY_CC_CCA register. */
 #ifndef RFA1_DEF_CHANNEL
-#define RFA1_DEF_CHANNEL	11
+#define RFA1_DEF_CHANNEL	26
 #endif
 
 #ifndef RF212_GC_TX_OFFS


### PR DESCRIPTION
Currently rfxlink radios are using mostly channel 11, and cc2420 uses channel 26. Therefor, they doesn't communicate with each other out of the box, which is a hard to detect "bug" for beginners.
Becouse cc2420 is the older stack, and channel 26 is the most wifi free channel*, I think we should switch to channel 26 on all capable hardware. Does anyone has a problem with this, or I can merge this?

"*" It overlaps with wifi channel 14, which is not available in most of the world, and slightly overlaps with wifi channel 13, which is not available in the US.
