### PR TITLE
Update TestPrintfAppC.nc

### DIFF
--- a/apps/tests/TestPrintf/TestPrintfAppC.nc
+++ b/apps/tests/TestPrintf/TestPrintfAppC.nc
@@ -47,7 +47,7 @@
 configuration TestPrintfAppC{
 }
 implementation {
-  components MainC, PrintfC, TestPrintfC;
+  components MainC, PrintfC, TestPrintfC,SerialStartC;
   components new TimerMilliC();
 
   TestPrintfC.Boot -> MainC;


### PR DESCRIPTION
Printf does not work properly in Telosb without SerialStartC.
