### PR TITLE
cc2420x 'status' variable not used warning

### DIFF
--- a/tos/chips/cc2420x/CC2420XDriverLayerP.nc
+++ b/tos/chips/cc2420x/CC2420XDriverLayerP.nc
@@ -380,28 +380,28 @@ implementation
 	{
 //for apps/PPPSniffer
 #ifdef PPPSNIFFER
-	    uint8_t i;
+		uint8_t i;
 #endif
 		// set pin directions
-    	call CSN.makeOutput();
-    	call VREN.makeOutput(); 		
-    	call RSTN.makeOutput(); 		
-    	call CCA.makeInput();
-    	call SFD.makeInput();
-    	call FIFO.makeInput();
-    	call FIFOP.makeInput();    		
+	    	call CSN.makeOutput();
+    		call VREN.makeOutput(); 		
+	    	call RSTN.makeOutput(); 		
+    		call CCA.makeInput();
+	    	call SFD.makeInput();
+    		call FIFO.makeInput();
+	    	call FIFOP.makeInput();    		
 
 		call FifopInterrupt.disable();
 		call SfdCapture.disable();
 
 		// CSN is active low		
-    	call CSN.set();
+	    	call CSN.set();
 
 		// start up voltage regulator
-    	call VREN.set();
-    	call BusyWait.wait( 600 ); // .6ms VR startup time
+    		call VREN.set();
+	    	call BusyWait.wait( 600 ); // .6ms VR startup time
     		
-    	// do a reset
+    		// do a reset
 		call RSTN.clr();
 		call RSTN.set();
     
@@ -432,20 +432,20 @@ implementation
 		cc2420X_iocfg0_t iocfg0;
 		cc2420X_mdmctrl0_t mdmctrl0;
 
-    	// do a reset
+	    	// do a reset
 		call RSTN.clr();
 		call RSTN.set();
 
 		// set up fifop polarity and threshold
 		iocfg0 = cc2420X_iocfg0_default;
 		iocfg0.f.fifop_thr = 127;
-      	writeRegister(CC2420X_IOCFG0, iocfg0.value);
+      		writeRegister(CC2420X_IOCFG0, iocfg0.value);
 		      
 		// set up modem control
 		mdmctrl0 = cc2420X_mdmctrl0_default;
 		mdmctrl0.f.reserved_frame_mode = 1; //accept reserved frames
 		mdmctrl0.f.adr_decode = 0; // disable
-      	writeRegister(CC2420X_MDMCTRL0, mdmctrl0.value);		
+	      	writeRegister(CC2420X_MDMCTRL0, mdmctrl0.value);		
 
 		state = STATE_PD;
 	}
@@ -554,7 +554,7 @@ implementation
 			&& state == STATE_PD  && isSpiAcquired() && call RadioAlarm.isFree() )
 		{
 			// start oscillator
-      		strobe(CC2420X_SXOSCON); 
+      			strobe(CC2420X_SXOSCON); 
 
 			call RadioAlarm.wait(PD_2_IDLE_TIME); // .86ms OSC startup time
 			state = STATE_PD_2_IDLE;
@@ -565,7 +565,7 @@ implementation
 			setChannel();
 
 			// start receiving
-      		strobe(CC2420X_SRXON); 
+      			strobe(CC2420X_SRXON); 
 			call RadioAlarm.wait(IDLE_2_RX_ON_TIME); // 12 symbol periods      			
 			state = STATE_IDLE_2_RX_ON;
 		}
@@ -573,17 +573,17 @@ implementation
 			&& state == STATE_RX_ON && isSpiAcquired() )
 		{
 			// disable SFD capture
-      		call SfdCapture.disable();	
+	      		call SfdCapture.disable();	
 
 			// stop receiving
-      		strobe(CC2420X_SRFOFF); 			
+      			strobe(CC2420X_SRFOFF); 			
 			state = STATE_IDLE;
 		}
 
 		if( cmd == CMD_TURNOFF && state == STATE_IDLE  && isSpiAcquired() )
 		{
-      		// stop oscillator
-      		strobe(CC2420X_SXOSCOFF); 
+      			// stop oscillator
+	      		strobe(CC2420X_SXOSCOFF); 
 
 			// do a reset
 			initRadio();


### PR DESCRIPTION
In CC2420XDriverLayerP, in RadioSend.send, variable 'status' of type cc2420X_status_t, is set at

status = strobe(CC2420X_STXON);

but it is never used, nor checked by RADIO_ASSERT.

The fix, also includes a quick pass for aligning the code indentation.
