### PR TITLE
Blip stack modifications according to RFC 6282

### DIFF
--- a/support/sdk/c/blip/lib6lowpan/lib6lowpan.c
+++ b/support/sdk/c/blip/lib6lowpan/lib6lowpan.c
@@ -196,8 +196,8 @@ uint8_t *pack_address(uint8_t *buf,
       *flags |= LOWPAN_IPHC_AM_16;
       memcpy(buf, &addr->s6_addr[14], 2);
       return buf += 2;
-    } else if (/* maybe it's a 16-bit address with the IID derived from the
-                  PANID + address */
+    } else if (/* It is of the format fe80::ff:fe00:16-bit short
+		*/
                (addr->s6_addr16[5] == htons(0x00ff) &&
                 addr->s6_addr16[6] == htons(0xfe00) &&
                 (((l2addr->ieee_mode == IEEE154_ADDR_SHORT) &&

--- a/tos/lib/net/blip/IPAddressP.nc
+++ b/tos/lib/net/blip/IPAddressP.nc
@@ -93,7 +93,7 @@ module IPAddressP {
     ieee154_laddr_t eui = call Ieee154Address.getExtAddr();
 
     if (addr->s6_addr16[0] == htons(0xfe80)) {
-      // link-local
+      // link-local address format : fe80::ff:fe00:16-bit short (RFC6282)
       if (m_short_addr &&
           addr->s6_addr16[5] == htons(0x00FF) &&
           addr->s6_addr16[6] == htons(0xFE00)) {

--- a/tos/lib/net/blip/IPDispatchP.nc
+++ b/tos/lib/net/blip/IPDispatchP.nc
@@ -101,7 +101,7 @@ int lowpan_extern_match_context(struct in6_addr *addr, uint8_t *ctx_id) {
   };
   uint8_t state = S_STOPPED;
   bool radioBusy;
-  bool ack_Required=TRUE;
+  bool ack_Required=TRUE;	//to check whether ack is required for the packet sent
   uint8_t current_local_label = 0;
   ip_statistics_t stats;
 

--- a/tos/lib/net/blip/IPNeighborDiscoveryP.nc
+++ b/tos/lib/net/blip/IPNeighborDiscoveryP.nc
@@ -56,7 +56,6 @@ module IPNeighborDiscoveryP {
 
   command error_t NeighborDiscovery.resolveAddress(struct in6_addr *addr,
                                                    ieee154_addr_t *link_addr) {
-    ieee154_panid_t panid = letohs(call Ieee154Address.getPanId());
 
     if (addr->s6_addr16[0] == htons(0xfe80)) {
       if (addr->s6_addr16[5] == htons(0x00FF) &&


### PR DESCRIPTION
According to RFC 6282 Header compression for 6LoWPAN ,generating IP Address from short address is of the form fe80:0000:0000:0000:0000:00ff:fe00:XXXX,where XXXX is the 16-bit short Address of the node.Whereas the current blip stack is generating IP Address in the form : fe80:0000:0000:0000:panid:00ff:fe00:XXXX,

Also one more modification in the blip stack is the fragmentation of multicast packets.In the fragmentation process,it divides whole packet into fragments,and will send first fragment and only after receiving the acknowledgement of the first fragment it will send the next fragment. Coming to our issue is that for multicast packets ,which will be broadcasted on layer2 , and are not acknowledged back... So, blip stack will never send the second fragment of the multicast packet as it will be waiting for the acknowledgement of the first fragment which will never come
