### PR TITLE
BLIP: fix for memory not freed on send queue fail

### DIFF
--- a/tos/lib/net/blip/IPDispatchP.nc
+++ b/tos/lib/net/blip/IPDispatchP.nc
@@ -548,6 +548,11 @@ void SENDINFO_DECR(struct send_info *si) {
       if (call SendQueue.enqueue(s_entry) != SUCCESS) {
         BLIP_STATS_INCR(stats.encfail);
         s_info->failed = TRUE;
+        // Because we were unable to add this fragment to the send queue we need
+        // to return the fragment and send entry to their respective pools.
+        // The s_info will be taken care of in done:
+        call FragPool.put(outgoing);
+        call SendEntryPool.put(s_entry);
         printf("drops: IP send: enqueue failed\n");
         goto done;
       }
@@ -565,7 +570,8 @@ void SENDINFO_DECR(struct send_info *si) {
       }
       call PacketLink.setRetryDelay(s_entry->msg, BLIP_L2_DELAY);
 
-      SENDINFO_INCR(s_info);}
+      SENDINFO_INCR(s_info);
+    }
 
     // printf("got %i frags\n", s_info->link_fragments);
   done:


### PR DESCRIPTION
If an outgoing packet fragment is unable to be added to the send queue, the fragment message_t and send_info were never put back in their pools. This patch cleans up that memory.

Addresses:

```
From: Jonas <i-tek@web.de>
Date: Tue, Jun 10, 2014 at 11:17 AM
Subject: [Tinyos-help] Blip - SendQueue - Potential memory leak?
To: tinyos-help@millennium.berkeley.edu


Hi everyone,

I am still working with BLIP and found a piece of code that made me
wonder if it could cause memory problems.
In the file <IPDispatchP.nc> is the interface command <IPLower.send>
that splits ip packets to fragments and enqueues these.
It starts by allocating a send_info and after this it allocates for
every fragment split both a send_entry and a message_t (from FragPool).
In all failure cases send_entry and message_t are put back to their
pools but when failing to enqueue them in SendQueue they aren't put back.
Since sendTask() only drops and 'put back's the fragments already
enqueued in SendQueue, we would loose a SendEntryPool-entry and a
FragPool-entry forever...

Some code to show what I meant:

struct send_info  *s_info = getSendInfo();

while(BYTESLEFTTOSEND < BYTESPUTINFRAGMENTS) {
    struct send_entry *s_entry  = call SendEntryPool.get();
    message_t *outgoing = call FragPool.get();

    if (call SendQueue.enqueue(s_entry) != SUCCESS) {
        s_info->failed = TRUE;
        // Shouldn't they be put back?
        // FragPool.put(outgoing);
        // SendEntryPool.put()
    }
}

Is this correct or did I do a mistake by ignoring something?

Best regards,
Jonas
```
