### PR TITLE
Set java lib dir to user directory if ./configure --prefix=... is used

### DIFF
--- a/tools/configure.ac
+++ b/tools/configure.ac
@@ -111,7 +111,8 @@ JDK=`dirname "$JAVAC_DIR"`
 AC_MSG_RESULT($JDK)
 
 AC_MSG_CHECKING(for location to put JARs)
-if test -d $prefix; then
+
+if test "$prefix" != "NONE"; then
     JAR_DIR="$prefix/lib/java"
 else
     JAR_DIR=`/bin/sh tinyos/misc/tos-locate-jre --jni`/../ext


### PR DESCRIPTION
At the current version of the build system, the `--prefix` parameter is ignored for the java target dir configuration: The .jar files are copied into a system directory. With this PR, the .jar files are copied into `$prefix/lib/java`.
The user has to adapt for example the `$CLASSPATH` manually like `$PYTHONPATH` for python.
