### PR TITLE
UDPEcho Compile Error Solved

### DIFF
--- a/apps/UDPEcho/Makefile
+++ b/apps/UDPEcho/Makefile
@@ -26,7 +26,7 @@ PFLAGS += -DRPL_ADDR_AUTOCONF=0
 ################################################################################
 
 # Configure the Neighbor Discovery mechanism
-PFLAGS += -DBLIP_SEND_ROUTER_SOLICITATIONS=1
+PFLAGS += -DBLIP_SEND_ROUTER_SOLICITATIONS=0
 PFLAGS += -DBLIP_SEND_ROUTER_ADVERTISEMENTS=0
 
 # Configure the number of times BLIP tries to send a packet and how long it


### PR DESCRIPTION
I was getting the "Makefile Separator Error" when i tried to compiled UDPEcho.
Solved by removing unneccessary text in the Makefile
