### PR TITLE
tkn154: fixing #312 by using TOSMAKE_FIRST_FLAGS make variable

### DIFF
--- a/tos/lib/mac/tkn154/Makefile.include
+++ b/tos/lib/mac/tkn154/Makefile.include
@@ -3,7 +3,7 @@
 
 TKN154_PLATFORM_INCLUDE ?= $(TINYOS_OS_DIR)/platforms/$(PLATFORM)/mac/tkn154/Makefile.include
 TKN154_EXTRAS += $(wildcard $(TINYOS_OS_DIR)/lib/mac/tkn154/extras/*.extra)
-CFLAGS += -I$(TINYOS_OS_DIR)/lib/mac/tkn154 \
+TOSMAKE_FIRST_FLAGS += -I$(TINYOS_OS_DIR)/lib/mac/tkn154 \
 	-I$(TINYOS_OS_DIR)/lib/mac/tkn154/dummies \
 	-I$(TINYOS_OS_DIR)/lib/mac/tkn154/interfaces/MCPS \
 	-I$(TINYOS_OS_DIR)/lib/mac/tkn154/interfaces/MLME \

--- a/tos/platforms/micaz/mac/tkn154/Makefile.include
+++ b/tos/platforms/micaz/mac/tkn154/Makefile.include
@@ -2,7 +2,7 @@
 # identical on the micaz platform (e.g. Ieee802154BeaconEnabledC.nc,
 # Ieee802154NonBeaconEnabledC.nc,TKN154TimingP.nc, etc.)
 
-CFLAGS += -I$(TINYOS_OS_DIR)/platforms/micaz/mac/tkn154 \
+TOSMAKE_FIRST_FLAGS += -I$(TINYOS_OS_DIR)/platforms/micaz/mac/tkn154 \
 	-I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154 \
 	-I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154/timer \
 	-I$(TINYOS_OS_DIR)/chips/cc2420_tkn154

--- a/tos/platforms/telosb/mac/tkn154/Makefile.include
+++ b/tos/platforms/telosb/mac/tkn154/Makefile.include
@@ -1,8 +1,8 @@
 ifdef TKN154_PIERCEBOARD
-CFLAGS += -I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154/timer/pierceboard
+TOSMAKE_FIRST_FLAGS += -I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154/timer/pierceboard
 endif
 
-CFLAGS += -I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154 \
+TOSMAKE_FIRST_FLAGS += -I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154 \
 	-I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154/timer \
 	-I$(TINYOS_OS_DIR)/chips/cc2420_tkn154
 

--- a/tos/platforms/z1/mac/tkn154/Makefile.include
+++ b/tos/platforms/z1/mac/tkn154/Makefile.include
@@ -2,7 +2,7 @@
 # identical on the z1 platform (e.g. Ieee802154BeaconEnabledC.nc,
 # Ieee802154NonBeaconEnabledC.nc,TKN154TimingP.nc, etc.)
 
-CFLAGS += -I$(TINYOS_OS_DIR)/platforms/z1/mac/tkn154 \
+TOSMAKE_FIRST_FLAGS += -I$(TINYOS_OS_DIR)/platforms/z1/mac/tkn154 \
 	-I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154 \
 	-I$(TINYOS_OS_DIR)/platforms/telosb/mac/tkn154/timer \
 	-I$(TINYOS_OS_DIR)/chips/cc2420_tkn154


### PR DESCRIPTION
This fixes issue #312 for telosb, micaz and z1 platforms.

tkn154-mac relies on overlaying some of the standard platform modules.
The old tkn154 makefile system didn't work after the Tinyos makefile system
was redesigned. The introduction of TOSMAKE_FIRST_FLAGS now allows to
hand over makefile includes to the compiler before anything else.
