### PR TITLE
Fix issue #324.

### DIFF
--- a/tos/chips/cc2420x/CC2420XDriverLayer.h
+++ b/tos/chips/cc2420x/CC2420XDriverLayer.h
@@ -37,8 +37,8 @@ typedef struct cc2420x_metadata_t
 	{
 		uint8_t power;
 		uint8_t rssi;
-	}; 
-} cc2420x_metadata_t; 
+	}__attribute__((packed)); 
+} __attribute__((packed)) cc2420x_metadata_t; 
 
 enum cc2420X_timing_enums {
 	CC2420X_SYMBOL_TIME = 16, // 16us	

--- a/tos/chips/cc2420x/CC2420XRadio.h
+++ b/tos/chips/cc2420x/CC2420XRadio.h
@@ -62,6 +62,6 @@ typedef struct cc2420xpacket_metadata_t
 	timestamp_metadata_t timestamp;
 	flags_metadata_t flags;
 	cc2420x_metadata_t cc2420x;
-} cc2420xpacket_metadata_t;
+} __attribute__((packed)) cc2420xpacket_metadata_t;
 
 #endif//__CC2420XRADIO_H__

--- a/tos/chips/cc2520/CC2520DriverLayer.h
+++ b/tos/chips/cc2520/CC2520DriverLayer.h
@@ -53,8 +53,8 @@ typedef struct cc2520_metadata_t
 		uint8_t power;
 	  uint8_t ack;
 		uint8_t rssi;
-	};
-} cc2520_metadata_t;
+	}__attribute__((packed));
+} __attribute__((packed)) cc2520_metadata_t;
 
 enum cc2520_reg_access_enums {
     CC2520_FREG_MASK      = 0x3F,    // highest address in FREG

--- a/tos/chips/cc2520/CC2520Radio.h
+++ b/tos/chips/cc2520/CC2520Radio.h
@@ -95,7 +95,7 @@ typedef struct cc2520packet_metadata_t
   timestamp_metadata_t timestamp;
   flags_metadata_t flags;
   cc2520_metadata_t cc2520;
-} cc2520packet_metadata_t;
+} __attribute__((packed)) cc2520packet_metadata_t;
 
 enum cc2520_security_enums{
   NO_SEC = 0,

--- a/tos/chips/rf212/RF212DriverLayer.h
+++ b/tos/chips/rf212/RF212DriverLayer.h
@@ -47,8 +47,8 @@ typedef struct rf212_metadata_t
 	{
 		uint8_t power;
 		uint8_t rssi;
-	};
-} rf212_metadata_t;
+	}__attribute__((packed));
+} __attribute__((packed)) rf212_metadata_t;
 
 enum rf212_registers_enum
 {

--- a/tos/chips/rf212/RF212Radio.h
+++ b/tos/chips/rf212/RF212Radio.h
@@ -73,6 +73,6 @@ typedef struct rf212packet_metadata_t
 	timestamp_metadata_t timestamp;
 	flags_metadata_t flags;
 	rf212_metadata_t rf212;
-} rf212packet_metadata_t;
+} __attribute__((packed)) rf212packet_metadata_t;
 
 #endif//__RF212RADIO_H__

--- a/tos/chips/rf230/RF230DriverLayer.h
+++ b/tos/chips/rf230/RF230DriverLayer.h
@@ -47,8 +47,8 @@ typedef struct rf230_metadata_t
 	{
 		uint8_t power;
 		uint8_t rssi;
-	};
-} rf230_metadata_t;
+	}__attribute__((packed));
+} __attribute__((packed)) rf230_metadata_t;
 
 enum rf230_registers_enum
 {

--- a/tos/chips/rf230/RF230Radio.h
+++ b/tos/chips/rf230/RF230Radio.h
@@ -73,6 +73,6 @@ typedef struct rf230packet_metadata_t
 	timestamp_metadata_t timestamp;
 	flags_metadata_t flags;
 	rf230_metadata_t rf230;
-} rf230packet_metadata_t;
+} __attribute__((packed)) rf230packet_metadata_t;
 
 #endif//__RF230RADIO_H__

--- a/tos/lib/fastserial/Serial.h
+++ b/tos/lib/fastserial/Serial.h
@@ -112,6 +112,6 @@ typedef struct serial_metadata {
   uint16_t space_for_crc;
   uint8_t length;
   nx_uint8_t protocol[3];
-} serial_metadata_t;
+} __attribute__((packed)) serial_metadata_t;
     
 #endif

--- a/tos/lib/rfxlink/layers/LowPowerListeningLayer.h
+++ b/tos/lib/rfxlink/layers/LowPowerListeningLayer.h
@@ -38,6 +38,6 @@
 typedef struct lpl_metadata_t
 {
 	uint16_t sleepint;
-} lpl_metadata_t;
+} __attribute__((packed)) lpl_metadata_t;
 
 #endif//__LOWPOWERLISTENINGLAYER_H__

--- a/tos/lib/rfxlink/layers/MetadataFlagsLayer.h
+++ b/tos/lib/rfxlink/layers/MetadataFlagsLayer.h
@@ -39,6 +39,6 @@ typedef struct flags_metadata_t
 {
 	// TODO: make sure that we have no more than 8 flags
 	uint8_t flags;
-} flags_metadata_t;
+} __attribute__((packed)) flags_metadata_t;
 
 #endif//__METADATAFLAGSLAYER_H__

--- a/tos/lib/rfxlink/layers/PacketLinkLayer.h
+++ b/tos/lib/rfxlink/layers/PacketLinkLayer.h
@@ -39,6 +39,6 @@ typedef struct link_metadata_t
 {
 	uint16_t maxRetries;
 	uint16_t retryDelay;
-} link_metadata_t;
+} __attribute__((packed)) link_metadata_t;
 
 #endif//__PACKETLINKLAYER_H__

--- a/tos/lib/rfxlink/layers/TimeStampingLayer.h
+++ b/tos/lib/rfxlink/layers/TimeStampingLayer.h
@@ -38,6 +38,6 @@
 typedef struct timestamp_metadata_t
 {
 	uint32_t timestamp;
-} timestamp_metadata_t;
+} __attribute__((packed)) timestamp_metadata_t;
 
 #endif//__TIMESTAMPINGLAYER_H__


### PR DESCRIPTION
Fix alignment problems in the metadata field of rfxlink stack when using 32bit microcontrollers.