### PR TITLE
This fix enables using RFA1TimeSyncMessageC with hardware acks

### DIFF
--- a/tos/chips/atm128rfa1/radio/RFA1TimeSyncMessageC.nc
+++ b/tos/chips/atm128rfa1/radio/RFA1TimeSyncMessageC.nc
@@ -85,7 +85,11 @@ implementation
 	TimeSyncMessageLayerC.PacketTimeStampRadio -> ActiveMessageC;
 	TimeSyncMessageLayerC.PacketTimeStampMilli -> ActiveMessageC;
 
+#ifdef RFA1_HARDWARE_ACK
+	components RFA1DriverHwAckC as DriverLayerC;
+#else
 	components RFA1DriverLayerC as DriverLayerC;
+#endif
 	TimeSyncMessageLayerC.LocalTimeRadio -> DriverLayerC;
 	TimeSyncMessageLayerC.PacketTimeSyncOffset -> DriverLayerC.PacketTimeSyncOffset;
 


### PR DESCRIPTION
This pull enables using RFA1TimeSyncMessageC with hardware acks.