### PR TITLE
Corrected list of targets for python tools

### DIFF
--- a/tools/tinyos/python/packet/Makefile.am
+++ b/tools/tinyos/python/packet/Makefile.am
@@ -1,6 +1,6 @@
 tospy_PYTHON = avrmote.py SerialIO.py SFProtocol.py __init__.py \
                PacketDispatcher.py SerialProtocol.py SFSource.py IO.py \
-               PacketSource.py Serial.py SocketIO.py Platform.py \
+               PacketSource.py SerialH.py SocketIO.py Platform.py \
                SerialSource.py ThreadTask.py
 
 tospydir = $(pythondir)/tinyos/packet


### PR DESCRIPTION
My previous fixes (https://github.com/tinyos/tinyos-main/pull/335) to Python tools broke the build process. Fixed now. Sorry for that.
