### PR TITLE
Changed call of CoAPClient.request_done to single pointer instead of double pointer.

### DIFF
--- a/tos/lib/net/coap/CoapUdpClientP.nc
+++ b/tos/lib/net/coap/CoapUdpClientP.nc
@@ -167,7 +167,7 @@ module CoapUdpClientP {
 
 	coap_get_data(received, &len, &databuf);
 	signal CoAPClient.request_done(received->hdr->code,
-				       (uint16_t)len, &databuf);
+				       (uint16_t)len, databuf);
 
 	//TODO: actually use the code from client.c:
 


### PR DESCRIPTION
The CoAPClient Interface constains an event called:
<pre>
event void request_done(uint8_t code, uint16_t len, void *data);
</pre>

I would expect the content by a single dereference of data, but a double dereference was necessary. I changed it in my commit to a single dereference.