### PR TITLE
changed value of RF212_DATA_MODE_DEFAULT to default value of TRX_CTRL_2

### DIFF
--- a/tos/chips/rf212/RF212DriverLayer.h
+++ b/tos/chips/rf212/RF212DriverLayer.h
@@ -144,7 +144,9 @@ enum rf212_trx_data_modes
 	RF212_DATA_MODE_OQPSK_RC_1000_SCR = 0x3E,
 	RF212_DATA_MODE_OQPSK_RC_1000 = 0x1E,
 
-	RF212_DATA_MODE_DEFAULT = 0x00, // BPSK_20
+	//register default is PHY mode BPSK-40
+	//with OQPSK_SCRAM_EN set to 1
+	RF212_DATA_MODE_DEFAULT = 0x24,
 };
 
 enum rf212_phy_rssi_enums


### PR DESCRIPTION
In tinyos-main/tos/chips/rf212/RF212DriverLayerP.nc (lines 249, 250 as well as 279, 280),
the value of register RF212_TRX_CTRL_2 is set to RF212_TRX_CTRL_2_VALUE only if
RF212_TRX_CTRL_2_VALUE != RF212_DATA_MODE_DEFAULT.

Hence, RF212_DATA_MODE_DEFAULT should be the default value of register 
TRX_CTRL_2, which is 0x24.