### PR TITLE
Making CoAP a bit more configurable by platforms

### DIFF
--- a/tools/tinyos/c/coap/config.h.tinyos
+++ b/tools/tinyos/c/coap/config.h.tinyos
@@ -70,5 +70,9 @@
 #ifndef BYTE_ORDER
 #endif /* BYTE_ORDER */
 
+#ifdef HAS_COAP_PLATFORM_INCLUDE
+#include "coap_platform.h"
+#endif
+
 #endif /* _CONFIG_H_ */
 

--- a/tools/tinyos/c/coap/mem.h
+++ b/tools/tinyos/c/coap/mem.h
@@ -11,8 +11,11 @@
 #define _COAP_MEM_H_
 
 #include <stdlib.h>
-
+#ifndef coap_malloc
 #define coap_malloc(size) malloc(size)
+#endif
+#ifndef coap_free
 #define coap_free(size) free(size)
+#endif
 
 #endif /* _COAP_MEM_H_ */

--- a/tools/tinyos/c/coap/net.h
+++ b/tools/tinyos/c/coap/net.h
@@ -24,7 +24,9 @@
 #ifdef WITH_TINYOS
 #include <lib6lowpan/ip.h>
 #include <lib6lowpan/nwbyte.h> // for htons()
+#ifndef HAS_SSIZE_T
 typedef uint16_t ssize_t;
+#endif
 #ifdef PLATFORM_MICAZ
 typedef uint16_t in_port_t; //TODO: mab: move to TinyOS part
 #endif

--- a/tools/tinyos/c/coap/uthash.h
+++ b/tools/tinyos/c/coap/uthash.h
@@ -67,8 +67,13 @@ typedef unsigned int uint32_t;
 #ifndef uthash_fatal
 #define uthash_fatal(msg) exit(-1)        /* fatal error (out of memory,etc) */
 #endif
-#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
-#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+
+#ifndef uthash_malloc
+#define uthash_malloc(sz) malloc(sz) /* malloc fcn */
+#endif
+#ifndef uthash_free
+#define uthash_free(ptr,sz) free(ptr) /* free fcn */
+#endif
 
 #define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
 #define uthash_expand_fyi(tbl)            /* can be defined to log expands   */


### PR DESCRIPTION
This PR makes some definitions in CoAP optional so they can be set by the platform, if necessary.
It's lso adding the possibility to include a coap_platform.h file.