### PR TITLE
nx type for ieee_eui64

### DIFF
--- a/tos/types/IeeeEui64.h
+++ b/tos/types/IeeeEui64.h
@@ -43,4 +43,8 @@ typedef struct ieee_eui64 {
   uint8_t data[IEEE_EUI64_LENGTH];
 } ieee_eui64_t;
 
+typedef nx_struct nx_ieee_eui64 {
+  nx_uint8_t data[IEEE_EUI64_LENGTH];
+} nx_ieee_eui64_t;
+
 #endif // IEEEEUI64_H


### PR DESCRIPTION
nesC will not let the ieee_eui64_t be embedded in packets(nx structures). So added a version made up of nx types to enable writing better-looking code :)