### PR TITLE
nx_ieee_eui64_t only when compiling with nesC

### DIFF
--- a/tos/types/IeeeEui64.h
+++ b/tos/types/IeeeEui64.h
@@ -43,10 +43,10 @@ typedef struct ieee_eui64 {
   uint8_t data[IEEE_EUI64_LENGTH];
 } ieee_eui64_t;
 
-#ifdef notdef
+#ifdef NESC
 typedef nx_struct nx_ieee_eui64 {
   nx_uint8_t data[IEEE_EUI64_LENGTH];
 } nx_ieee_eui64_t;
-#endif
+#endif // NESC
 
 #endif // IEEEEUI64_H


### PR DESCRIPTION
Solve #376 without actually losing the nx_ieee_eui64_t when compiling with nesC for TinyOS.