### PR TITLE
Tossim sim-sf sf headers

### DIFF
--- a/tos/lib/tossim/sf/sim/SerialActiveMessageC.nc
+++ b/tos/lib/tossim/sf/sim/SerialActiveMessageC.nc
@@ -12,8 +12,8 @@
  *   notice, this list of conditions and the following disclaimer in the
  *   documentation and/or other materials provided with the
  *   distribution.
- * - Neither the name of Toilers Research Group - Colorado School of 
- *   Mines  nor the names of its contributors may be used to endorse 
+ * - Neither the name of Toilers Research Group - Colorado School of
+ *   Mines  nor the names of its contributors may be used to endorse
  *   or promote products derived from this software without specific
  *   prior written permission.
  *
@@ -64,7 +64,7 @@ implementation {
 
     message_t buffer;
     message_t* bufferPointer = &buffer;
-    
+
     message_t* sendMsgPtr = NULL;
 
     serial_header_t* getHeader(message_t* amsg) {
@@ -89,11 +89,11 @@ implementation {
                                             uint8_t len) {
         error_t err;
         serial_header_t* header = getHeader(amsg);
-        
+
         header->type = id;
         header->dest = addr;
         // For out going serial messages we'll use the real TOS_NODE_ID
-        header->src = TOS_NODE_ID;
+        // header->src = TOS_NODE_ID;
         header->length = len;
         err = call Model.send((int)addr, amsg, len + sizeof(serial_header_t));
         return err;
@@ -128,7 +128,7 @@ implementation {
         dbg("Serial", "Sending serial message (%p) of type %hhu and length %hhu @ %s.\n",
             msg, call AMPacket.type(msg), len, sim_time_string());
         sim_sf_dispatch_packet((void*)msg, len);
-        
+
         post modelSendDone ();
 
         return SUCCESS;
@@ -141,11 +141,11 @@ implementation {
         void* payload;
 
         memcpy(bufferPointer, msg, sizeof(message_t));
-	
-	if (msg != NULL) {
-	  free(msg);
-	}
-	
+
+        if (msg != NULL) {
+            free(msg);
+        }
+
         payload = call Packet.getPayload(bufferPointer, call Packet.maxPayloadLength());
         len = call Packet.payloadLength(bufferPointer);
 
@@ -276,10 +276,10 @@ implementation {
 
     sim_event_t* allocate_serial_deliver_event(int node, message_t* msg, sim_time_t t) {
         sim_event_t* evt = (sim_event_t*)malloc(sizeof(sim_event_t));
-	message_t* newMsg = (message_t*)malloc(sizeof(message_t));
+        message_t* newMsg = (message_t*)malloc(sizeof(message_t));
         uint8_t payloadLength = ((serial_header_t*)msg->header)->length;
         memcpy(getHeader(newMsg), msg, sizeof(serial_header_t) + payloadLength);
-	
+
         evt->mote = node;
         evt->time = t;
         evt->handle = serial_active_message_deliver_handle;

--- a/tos/lib/tossim/sf/tossim.c
+++ b/tos/lib/tossim/sf/tossim.c
@@ -63,7 +63,7 @@ Variable::Variable(char* str, char* formatStr, int array, int which) {
   format = formatStr;
   isArray = array;
   mote = which;
-  
+
   int sLen = strlen(name);
   realName = (char*)malloc(sLen + 1);
   memcpy(realName, name, sLen + 1);
@@ -101,10 +101,10 @@ static unsigned int tossim_hash(void* key) {
   char* str = (char*)key;
   unsigned int hashVal = 0;
   int c;
-  
+
   while ((c = *str++))
     hashVal = c + (hashVal << 6) + (hashVal << 16) - hashVal;
-  
+
   return hashVal;
 }
 
@@ -179,7 +179,7 @@ Variable* Mote::getVariable(char* name) {
   char* typeStr = (char*)"";
   int isArray;
   Variable* var;
-  
+
   var = (Variable*)hashtable_search(varTable, name);
   if (var == NULL) {
     // Could hash this for greater efficiency,
@@ -210,7 +210,7 @@ void Mote::createNoiseModel() {
 }
 
 int Mote::generateNoise(int when) {
-  return (int)sim_noise_generate(id(), when);
+  return (int)sim_noise_generate(id(), sim_mote_get_radio_channel(id()), when);
 }
 
 Tossim::Tossim(nesc_app_t* n) {


### PR DESCRIPTION
This commit fixes sim-sf serial packet headers, which are sent incorrectly - I would consider the sim-sf target to be broken in the current master. The header does not start from offset 0, but in master it is forwarded like that. So this is fixed here.

Additionally there is a logic change here, originally the sim-sf serialforwarder routes packets to the serial port of a node based on the destination address in the serial packet, seems to make sense, but what is the node supposed to do with it then - it won't know where to send it next, can only consume it. I changed it so that the packet gets routed according to the source instead - the source of the packet needs to be set to the address of the node that the packets should end up in and the node can then send it out over radio to the destination address. If a packet needs to be sent only to that specific node, then the source and destination addresses would be the same. This closely mirrors what happens with real nodes and the BaseStation application, which does not care about the source in the serial packet. Also SerialAM no longer sets the source address on node->serial packets(again, behaviour is the same with the real SerialActiveMessage, where the address only gets set when using a Sender and not when using AM directly). Feel free to fight this change, but since the sim-sf is currently broken in master, then I am guessing that no-one is actually using sim-sf and it should be safe to do this.