### PR TITLE
Correct comments in 4bitle

### DIFF
--- a/tos/lib/net/4bitle/LinkEstimator.nc
+++ b/tos/lib/net/4bitle/LinkEstimator.nc
@@ -54,7 +54,7 @@ interface LinkEstimator {
   /* pin a neighbor so that it does not get evicted */
   command error_t pinNeighbor(am_addr_t neighbor);
 
-  /* pin a neighbor so that it does not get evicted */
+  /* unpin a neighbor so that it could get evicted */
   command error_t unpinNeighbor(am_addr_t neighbor);
 
   /* called when an acknowledgement is received; sign of a successful

--- a/tos/lib/net/4bitle/LinkEstimatorP.nc
+++ b/tos/lib/net/4bitle/LinkEstimatorP.nc
@@ -495,7 +495,7 @@ implementation {
     return SUCCESS;
   }
 
-  // pin a neighbor so that it does not get evicted
+  // unpin a neighbor so that it could get evicted
   command error_t LinkEstimator.unpinNeighbor(am_addr_t neighbor) {
     uint8_t nidx = findIdx(neighbor);
     if (nidx == INVALID_RVAL) {


### PR DESCRIPTION
Hi, 

It seems that there are two comment mistakes in the 4bitle. My idea is that the comment for "unpinNeighor" may be incorrect due to clerical error.

Would someone give me some information on this issue?

Thanks in advance.

Best Regards,
Yaoshicn