### PR TITLE
strict aliasing / dereferencing type-punned pointer (avr8-gnu-toolchain 3.4.5.1522)

### DIFF
--- a/tos/chips/ms5607/Ms5607P.nc
+++ b/tos/chips/ms5607/Ms5607P.nc
@@ -116,14 +116,14 @@ implementation {
       }break;
       case S_READ_PRESSURE_CMD:
       case S_READ_PRESSURE:{
-        uint32_t measurment=(*((nx_uint32_t*)i2cBuffer))>>8;//conversion from big-endian
+        uint32_t measurment=((uint32_t)i2cBuffer[0] << 16) | ((uint32_t)i2cBuffer[1] << 8) | i2cBuffer[2];
         state=S_IDLE;
         call BusPowerManager.releasePower();
         signal ReadPressure.readDone(lastError, measurment);
       }break;
       case S_READ_TEMP_CMD:
       case S_READ_TEMP:{
-	uint32_t measurment=(*((nx_uint32_t*)i2cBuffer))>>8;
+        uint32_t measurment=((uint32_t)i2cBuffer[0] << 16) | ((uint32_t)i2cBuffer[1] << 8) | i2cBuffer[2];
         state=S_IDLE;
         call BusPowerManager.releasePower();
         signal ReadTemperature.readDone(lastError, measurment);

--- a/tos/chips/sht21/Sht21HumidLogicP.nc
+++ b/tos/chips/sht21/Sht21HumidLogicP.nc
@@ -154,7 +154,7 @@ implementation
 		{
 			oldError = err;
 			if( oldError == SUCCESS )
-				oldHumidData =  *((nx_uint16_t*)buffer);;
+				oldHumidData = ((uint16_t)buffer[0] << 8) | buffer[1];
 		}
 		
 		state = S_IDLE;

--- a/tos/chips/sht21/Sht21TempLogicP.nc
+++ b/tos/chips/sht21/Sht21TempLogicP.nc
@@ -162,7 +162,7 @@ implementation
 		{
 			oldError = err;
 			if( oldError == SUCCESS )
-				oldTempData =  *((nx_uint16_t*)buffer);
+				oldTempData = ((uint16_t)buffer[0] << 8) | buffer[1];
 		}
 		
 		state = S_IDLE;


### PR DESCRIPTION
With avr-gcc 4.8.1 (avr8-gnu-toolchain 3.4.5.1522 [1])
some code compiles with "dereferencing type-punned pointer" warnings.
This is a fix to meet strict aliasing.
