### PR TITLE
Fix sim.extra regex to match Python 2.7.x where x is two digits

### DIFF
--- a/support/make/extras/sim.extra
+++ b/support/make/extras/sim.extra
@@ -7,7 +7,7 @@ LIBS = -lm -lstdc++
 PFLAGS += -DTOSSIM -fnesc-nido-tosnodes=1000 -fnesc-simulate -fnesc-nido-motenumber='sim_node\(\)' -fnesc-gcc=$(GCC)
 PFLAGS += -I%T/lib/tossim
 WFLAGS = -Wno-nesc-data-race
-PYTHON_VERSION ?= $(shell python --version 2>&1 | sed 's/Python \([0-9]\)\.\([0-9]\)\.[0-9]+\{0,1\}.*/\1.\2/')
+PYTHON_VERSION ?= $(shell python --version 2>&1 | sed 's/Python \([23]\)\.\([0-9]\)\.[0-9]+\{0,1\}.*/\1.\2/')
 
 TOSMAKE_BUILD_DIR = simbuild/$(PLATFORM)
 TOSSIMPY_DIR      = $(TINYOS_OS_DIR)/lib/tossim

--- a/support/make/extras/sim.extra
+++ b/support/make/extras/sim.extra
@@ -7,7 +7,7 @@ LIBS = -lm -lstdc++
 PFLAGS += -DTOSSIM -fnesc-nido-tosnodes=1000 -fnesc-simulate -fnesc-nido-motenumber='sim_node\(\)' -fnesc-gcc=$(GCC)
 PFLAGS += -I%T/lib/tossim
 WFLAGS = -Wno-nesc-data-race
-PYTHON_VERSION ?= $(shell python --version 2>&1 | sed 's/Python 2\.\([0-9]\)\.[0-9]+\{0,1\}/2.\1/')
+PYTHON_VERSION ?= $(shell python --version 2>&1 | sed 's/Python \([0-9]\)\.\([0-9]\)\.[0-9]+\{0,1\}.*/\1.\2/')
 
 TOSMAKE_BUILD_DIR = simbuild/$(PLATFORM)
 TOSSIMPY_DIR      = $(TINYOS_OS_DIR)/lib/tossim


### PR DESCRIPTION
Fix sim.extra regex to match Python 2.7.x versions where x is two digits. Also support Python 3 and development versions of Python.

I posted this fix to the tinyos.users mailing list, but the post hasn't been approved yet. See the thread at: https://www.millennium.berkeley.edu/pipermail/tinyos-help/2017-January/059055.html