### PR TITLE
About OF0Function Component...

### DIFF
--- a/tos/lib/net/rpl/RPLOF0P.nc
+++ b/tos/lib/net/rpl/RPLOF0P.nc
@@ -111,7 +111,7 @@ implementation{
     }
 
     // printf("RPLOF: OF0 PARENT rank %d \n", parentSet[desiredParent].rank);
-    nodeEtx = parentNode->etx_hop;
+    nodeEtx = parentNode->etx_hop + parentNode->etx;
     nodeRank = parentNode->rank + min_hop_rank_inc;
 
     if (nodeRank < min_hop_rank_inc)

--- a/tos/lib/net/rpl/RPLOF0P.nc
+++ b/tos/lib/net/rpl/RPLOF0P.nc
@@ -88,7 +88,7 @@ implementation{
   }
 
   command uint16_t RPLOF.getObjectValue() {
-    return nodeEtx;
+    return (call RPLRankInfo.isRoot() == TRUE) ? 0 : nodeEtx;
   }
 
   /* Current parent */


### PR DESCRIPTION
In ObjectFunction0 Component(calls OF0),
I found some bugs about ETX.

First, in "recalculateRank()" command of RPLOF interface, the variable "nodeEtx" was being assigned just parentNode->etx_hop. 
But in this implementation, variable "etx_hop" is the etx value only between my parent(candidate) and me.
And when a node sends DIO message, it inserts "nodeEtx" value into the etx value of DIO message.
That is, when another node received DIO message, the node is missing that the etx variable in DIO message is the etx value from root to sender although this etx variable is between sender and his parent.
So I suggest you to correct this bug by modifying the instruction which calculates variable "nodeEtx" to add variable etx_hop and variable etx.

Second, in "getObjectValue" command of RPLOF interface, it always return "nodeEtx" value.
But if the node is root, the etx value will be 0 because in this logic, the etx value is an indicator of expected transmission count which how many the sender sends.
So I propose you to correct that the root sends an etx value 0 instead of initial value(current, divideRank, 10).