### PR TITLE
TinyRPL Bug Fix

### DIFF
--- a/tos/lib/net/rpl/RPLDAORoutingEngineP.nc
+++ b/tos/lib/net/rpl/RPLDAORoutingEngineP.nc
@@ -367,6 +367,7 @@ generic module RPLDAORoutingEngineP() {
         if (memcmp_rpl((uint8_t*)entry->next_hop.s6_addr,
                        (uint8_t*)iph->ip6_src.s6_addr, 16) == TRUE) {
           // same old destination with same DTSN
+		  new_key = entry->key;
         } else {
           // new next hop for an existing downswards node
           call RPLRouteInfo.setDTSN((call RPLRouteInfo.getDTSN()) + 1);

--- a/tos/lib/net/rpl/RPLOF0P.nc
+++ b/tos/lib/net/rpl/RPLOF0P.nc
@@ -134,9 +134,8 @@ implementation{
 
     parentNode = call ParentTable.get(min);
 
-    while ((!parentNode->valid) &&
-           (min < MAX_PARENT) &&
-           (parentNode->rank != INFINITE_RANK)) {
+    while ((min < MAX_PARENT) &&
+			(!parentNode->valid || parentNode->rank >= nodeRank)) {
       min++;
       parentNode = call ParentTable.get(min);
     }

--- a/tos/lib/net/rpl/RPLRankP.nc
+++ b/tos/lib/net/rpl/RPLRankP.nc
@@ -316,7 +316,7 @@ implementation {
       tempEtx_hop = parentSet[indexset].etx_hop;
       parentSet[indexset] = parent;
 
-      if (tempEtx_hop > INIT_ETX && tempEtx_hop < BLIP_L2_RETRIES) {
+      if (tempEtx_hop > INIT_ETX && tempEtx_hop < BLIP_L2_RETRIES*divideRank) {
         tempEtx_hop = tempEtx_hop-INIT_ETX;
         if (tempEtx_hop < divideRank)
           tempEtx_hop = INIT_ETX;


### PR DESCRIPTION
I have evaluated TinyRPL for some years and found out some bugs, which cause malfunction.
This pull request is simply reporting these bugs.

1) RPLDAORoutingEngineP.nc
 - A node must set "new_key" even when receiving a DAO from an existing entry, which enables to reset "path_lifetime". If not, each entry in the downlink routing table will be always removed after the initial path_lifetime.

2) RPLOF0P.nc
 - Here, "min" value should be increased when a target entry is not a valid parent. However, the current "IF" conditions cannot tell if the entry is valid or not.

3) RPLRankP.nc
 - "INIT_ETX" is not a pure ETX but ETX*divideRank.  "tempEtx_hop" also has divideRank in it. 
    So, we should replace "BLIP_L2_RETRIES" to BLIP_L2_RETRIES*divideRank for fairness. 