### PR TITLE
Remove Special Character

### DIFF
--- a/tools/tinyos/java/net/tinyos/mviz/DLinkModel.java
+++ b/tools/tinyos/java/net/tinyos/mviz/DLinkModel.java
@@ -86,7 +86,7 @@ implements Serializable {
     }
 
     /**
-     * Get the link flag（startNode+“ ”+endNode）
+     * Get the link flag(startNode+“ ”+endNode)
      * @return 
      */
     public String getLinkFlag(){


### PR DESCRIPTION
Causes "unmappable character for encoding ASCII" error when compiling due to using a "）" instead of a ")"