### PR TITLE
Update tos-install-jni.in

### DIFF
--- a/tools/tinyos/misc/tos-install-jni.in
+++ b/tools/tinyos/misc/tos-install-jni.in
@@ -11,8 +11,8 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ -x /bin/cygwin1.dll ]; then
-  java=`tos-locate-jre --java`
   bits=32
+  java=`tos-locate-jre --java`
   if [ $? -ne 0 ]; then
     echo "java command not found - assuming 32 bits"
   elif file -L "$java/java" | grep -qe '64-bit\|x86-64'; then #java7 on windows7 only prints x86-64


### PR DESCRIPTION
The exit status of `bits=32` shall be `0`, so we should exchange line 14 and line 15.
When I changed this file, file 31 was also modified automatically, but I don't know why.