### PR TITLE
Changed to ASCII quotes.

### DIFF
--- a/tools/tinyos/java/net/tinyos/mviz/DLinkModel.java
+++ b/tools/tinyos/java/net/tinyos/mviz/DLinkModel.java
@@ -86,7 +86,7 @@ implements Serializable {
     }
 
     /**
-     * Get the link flag(startNode+“ ”+endNode)
+     * Get the link flag(startNode+" "+endNode)
      * @return 
      */
     public String getLinkFlag(){


### PR DESCRIPTION
Changed to ASCII quotes as it would error out when compiling TinyOS.