### PR TITLE
Update platform.h

### DIFF
--- a/tos/platforms/iris/platform.h
+++ b/tos/platforms/iris/platform.h
@@ -1,2 +1,3 @@
+#define __AVR_ATmega1281__
 #include <avr/wdt.h>
 #define platform_bootstrap() { MCUSR=0; wdt_disable(); }


### PR DESCRIPTION
fixed for this error

usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/io.h:623:6: warning: #warning "device type not defined"
In file included from /usr/src/tinyos/tos/platforms/iris/platform.h:1,
                 from /usr/src/tinyos/tos/system/tos.h:43:
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h: In function `wdt_enable':
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:406: `WDT' undeclared (first use in this function)
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:406: (Each undeclared identifier is reported only once
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:406: for each function it appears in.)
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:417: `WDCE' undeclared (first use in this function)
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:417: `WDE' undeclared (first use in this function)
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h: In function `wdt_disable':
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:446: `WDT' undeclared (first use in this function)
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:460: `WDCE' undeclared (first use in this function)
/usr/lib/gcc/avr/4.9.2/../../../avr/include/avr/wdt.h:460: `WDE' undeclared (first use in this function)
In file included from /usr/src/tinyos/tos/system/TinySchedulerC.nc:52:
In component `McuSleepC':
...