### PR TITLE
Perhaps fix an overflow bug relate to timer

### DIFF
--- a/tos/lib/timer/VirtualizeTimerC.nc
+++ b/tos/lib/timer/VirtualizeTimerC.nc
@@ -105,6 +105,7 @@ implementation
        runtime cost). */
     uint32_t now = call TimerFrom.getNow();
     int32_t min_remaining = (1UL << 31) - 1; /* max int32_t */
+    int32_t max_int32 = min_remaining;    
     bool min_remaining_isset = FALSE;
     uint16_t num;
 
@@ -118,6 +119,15 @@ implementation
 	  {
 	    uint32_t elapsed = now - timer->t0;
 	    int32_t remaining = timer->dt - elapsed;
+
+	    /* If the value of timer's destination greater than max int32_t, 
+	       then the virtual timer is ignored to avoid the fact that all 
+	       of other tasks is hard to get runing time and the battery is
+	       quickly exhausted. And the system may crash.*/
+	    if(timer->dt > max_int32) {
+	      dbg("Value error", "The timer's destination value is too high\n");
+	      continue;
+	    }
 
 	    if (remaining < min_remaining)
 	      {


### PR DESCRIPTION
Hello, I find a bug relate to timer system and try to fix it, which causes overflow task to execute and all of other task to fail. The system will crash and the battery is quickly exhausted (not "slightly higher runtime cost" in the comments of code author because 'remaining' will always be negative and cannot be corrected). The following code can trigger bugs
```c
call Timer2.startPeriodic( 111UL << 28);  
```
Although the code author noticed the overflow problem, it did not solve it.
This problem appears to have been triggered in an earlier CTP protocol, but it has not really been resolved. [ https://github.com/tinyos/tinyos-main/commit/11ff964 ]

The idea my fix is to disable the timer that triggered the bug, so that other tasks in the system can handle the events normally. And the battery won't be drained quickly.